### PR TITLE
Changing Dev and Data instructions to facilitate OneDrive etc.

### DIFF
--- a/src/interviews/data.md
+++ b/src/interviews/data.md
@@ -127,6 +127,6 @@ Once the temporary data has been loaded into the data mart, transform the data i
 
 ## Completion
 
-When the solution is above is complete, save any artefacts created and share them with the Consultant/ Talent Acquisition Specialist who contacted you from Telstra Purple. If also possible, please keep your Cloud service provider environment running until the in-person technical interview has been conducted or as otherwise advised.
+When the solution above is complete, save any artefacts created and share them with the Consultant/Talent Acquisition Specialist who contacted you from Telstra Purple. If also possible, please keep your Cloud service provider environment running until the in-person technical interview has been conducted or as otherwise advised.
 
 When the solution is code complete, share your source code and supporting artefacts with the Consultant/ Talent Acquisition Specialist who contacted you from Telstra Purple.

--- a/src/interviews/data.md
+++ b/src/interviews/data.md
@@ -128,5 +128,3 @@ Once the temporary data has been loaded into the data mart, transform the data i
 ## Completion
 
 When the solution above is complete, save any artefacts created and share them with the Consultant/Talent Acquisition Specialist who contacted you from Telstra Purple. If also possible, please keep your Cloud service provider environment running until the in-person technical interview has been conducted or as otherwise advised.
-
-When the solution is code complete, share your source code and supporting artefacts with the Consultant/ Talent Acquisition Specialist who contacted you from Telstra Purple.

--- a/src/interviews/data.md
+++ b/src/interviews/data.md
@@ -127,4 +127,6 @@ Once the temporary data has been loaded into the data mart, transform the data i
 
 ## Completion
 
-When the solution is above is complete, save any artefacts created into a source code repository (E.g. GitHub) and share this repository (or artefacts) with the Consultant/ Talent Acquisition Specialist who contacted you from Telstra Purple. If also possible, please keep your Cloud service provider environment running until the in-person technical interview has been conducted or as otherwise advised.
+When the solution is above is complete, save any artefacts created and share them with the Consultant/ Talent Acquisition Specialist who contacted you from Telstra Purple. If also possible, please keep your Cloud service provider environment running until the in-person technical interview has been conducted or as otherwise advised.
+
+When the solution is code complete, share your source code and supporting artefacts with the Consultant/ Talent Acquisition Specialist who contacted you from Telstra Purple.

--- a/src/interviews/development.md
+++ b/src/interviews/development.md
@@ -89,4 +89,4 @@ Output: 3,2,NORTH
 
 ## Code Complete
 
-When the solution is code complete, save the source code to a repository (e.g. GitHub) and share this repository (or artefacts) with the Consultant/ Talent Acquisition Specialist who contacted you from Telstra Purple.
+When the solution is code complete, share your source code and supporting artefacts (e.g. GitHub/OneDrive/Google Drive) with the Consultant/ Talent Acquisition Specialist who contacted you from Telstra Purple.


### PR DESCRIPTION
Following feedback from Casey Allen, Associate Squad Lead in WANTSA, I'm changing the blurbage on how to share the code with the consultant/TAM so it can be kept in line with how things are done west vs. how they're done east. 

Cloud and DevOps remain unchanged. We would expect people to use GitHub or similiar source control in these tests. 